### PR TITLE
Removed background gridline to use background on images

### DIFF
--- a/src/app/patient/[patientId]/page.tsx
+++ b/src/app/patient/[patientId]/page.tsx
@@ -318,8 +318,8 @@ export default function PatientInfo({
           <div className="col-span-3">
             <div className="w-full flex flex-col rounded-md bg-white shadow-md border border-gray-200 h-5/6">
               <div
-                style={{ backgroundImage: `url('/EKG_Background.png')` }}
-                className="w-full flex flex-col rounded-md bg-cover bg-center shadow-md border border-gray-200 h-5/6"
+              // style={{ backgroundImage: `url('/EKG_Background.png')` }}
+              // className="w-full flex flex-col rounded-md bg-cover bg-center shadow-md border border-gray-200 h-5/6"
               >
                 {/* Will be image wrapper at some point for manipulation */}
                 {projects.map(


### PR DESCRIPTION
Background gridline was getting stretched so i just removed it since they all have built in grids in the backgrounds